### PR TITLE
Adiciona cálculo do retorno esperado com CAPM

### DIFF
--- a/turingquant/metrics.py
+++ b/turingquant/metrics.py
@@ -51,6 +51,25 @@ def beta(returns, benchmark):
 
     return cov / benchmark_vol
 
+def capm(returns, market_returns, risk_free):
+    """
+    Essa função, com o fornecimento dos retornos de um portfólio ou ativo, dos retornos do mercado e da retorno sem risco, 
+    calcula o retorno esperado pela abordagem CAPM. Essa abordagem considera o mercado (benchmark) e as relações com os ativos 
+    como parâmetro para estimar o retorno esperado.
+
+    Args:
+        returns (pd.Series ou np.array): vetor de retornos
+        market_returns (pd.Series ou np.array): vetor de retornos do mercado ou benchmark
+        risk_free (float): retorno livre de risco
+        
+    Returns:
+        float: retorno esperado pela abordagem CAPM
+    """
+    beta = beta(returns, market_returns)
+    expected_market_returns = market_returns.mean()
+    expected_returns = risk_free + beta * (expected_market_returns - risk_free)
+    return expected_returns
+
 
 def alpha(start_price, end_price, dividends):
     """


### PR DESCRIPTION
Olá pessoal.

Esse PR adiciona a métrica de calculo de retorno esperado com CAPM (Capital Asset Pricing Model). Essa precificação é reita pela seguinte fórmula:
![image](https://user-images.githubusercontent.com/30242403/117815548-fb11e280-b23b-11eb-9f6f-88f30cd8c8cb.png)
Então a ideia é que vc usa o mercado pra precificar um ativo. Você passa os retornos de um ativo ou portfolio e se calcula o beta, que é uma medida de correlação com o mercado. Ai é estimado o retorno do ativo ou portfólio considerando o quão descorrelacionado seu portfólio é do mercado.
