### PR TITLE
Refatoração: módulo de plot de métricas

### DIFF
--- a/turingquant/__init__.py
+++ b/turingquant/__init__.py
@@ -1,2 +1,2 @@
-from . import benchmark, metrics, support, optimizers
+from . import benchmark, metrics, support, optimizers, plot_metrics
 

--- a/turingquant/metrics.py
+++ b/turingquant/metrics.py
@@ -2,8 +2,6 @@
 
 import numpy as np
 import pandas as pd
-import plotly.express as px
-
 
 def sharpe_ratio(returns, risk_free=0, time_scale=252):
     """
@@ -19,8 +17,8 @@ def sharpe_ratio(returns, risk_free=0, time_scale=252):
         float: índice de sharpe do ativo.
     """
 
-    expected_returns = returns.mean()
-    risk = returns.std()
+    expected_returns = np.mean(returns)
+    risk = np.std(returns)
 
     sharpe = (expected_returns * time_scale - risk_free) / (risk * np.sqrt(time_scale))
 
@@ -41,9 +39,7 @@ def beta(returns, benchmark):
 
     assert returns.shape[0] == benchmark.shape[0], "Séries temporais com dimensões diferentes"
 
-    concat = np.matrix([returns, benchmark])
-
-    cov = np.cov(concat)[0][1]
+    cov = np.cov(returns, benchmark)[0][1]
 
     benchmark_vol = np.var(benchmark)
 
@@ -85,13 +81,13 @@ def alpha(start_price, end_price, dividends):
     return (end_price + dividends - start_price) / start_price
 
 
-def drawdown(returns, plot=False):
+def drawdown(returns):
     """
-    Calcula e plota o drawdown percentual para uma série de retornos.
+    Calcula o drawdown percentual para uma série de retornos.
 
     Args:
         returns (pd.Series): série de retornos para a qual será calculado o drawdown.
-        plot (bool): se `True`, plota o gráfico de underwater (drawdown consoante o tempo).
+    
     Returns:
         pd.Series: uma série com os valores percentuais do Drawdown.
     """
@@ -100,26 +96,16 @@ def drawdown(returns, plot=False):
     peeks = cum_returns.cummax()
     drawdowns = pd.Series((cum_returns/peeks - 1)*100,
                           name='Drawdown')
-
-    if plot:
-        fig = px.area(drawdowns, x=drawdowns.index,
-                      y='Drawdown', title='Underwater')
-        fig.update_xaxes(title_text='Tempo')
-        fig.update_yaxes(title_text='Drawdown (%)')
-        fig.show()
-
     return drawdowns
 
-
-def rolling_beta(returns, benchmark, window=60, plot=False):
+def rolling_beta(returns, benchmark, window=60):
     """
-    Plota o beta móvel para um ativo e um benchmark de referência, na forma de séries de retornos.
+    Calcula o beta móvel para um ativo e um benchmark de referência, na forma de séries de retornos.
 
     Args:
         returns (array): série de retornos para o qual o beta será calculado.
         benchmark (array): série de retornos para usar de referência no cálculo do beta.
         window (int): janela móvel para calcular o beta ao longo do tempo.
-        plot (bool): se `True`, plota um gráfico de linha com o beta ao longo do tempo.
 
     Returns:
         pd.Series: uma série com os valores do Beta para os últimos `window` dias.
@@ -128,44 +114,16 @@ def rolling_beta(returns, benchmark, window=60, plot=False):
     """
     rolling_beta = pd.Series([beta(returns[i-window:i], benchmark[i-window:i])
                               for i in range(window, len(returns))], index=returns[window:].index)
-    if plot:
-        fig = px.line(rolling_beta, title="Beta móvel")
-        overall_beta = beta(returns, benchmark)
-        fig.update_layout(shapes=[
-            dict(
-                type='line',
-                xref='paper', x0=0, x1=1,
-                yref='y', y0=overall_beta, y1=overall_beta,
-                line=dict(
-                    color='grey',
-                    width=2,
-                    dash='dash'
-                )
-            )
-        ], annotations=[
-            dict(
-                text='beta total: %.3f' % overall_beta,
-                xref='paper', x=0.05,
-                yref='y', y=overall_beta,
-                xanchor='left'
-            )
-        ])
-        fig.update_layout(showlegend=False)
-        fig.update_xaxes(title_text='Tempo')
-        fig.update_yaxes(title_text='Beta móvel: ' + str(window) + ' períodos')
-        fig.show()
     return rolling_beta
 
-
-def rolling_sharpe(returns, window, risk_free=0, plot=False):
+def rolling_sharpe(returns, window, risk_free=0):
     """
-    Plota o sharpe móvel para um ativo e um benchmark de referência, na forma de séries de retornos.
+    Calcula o sharpe móvel para um ativo e um benchmark de referência, na forma de séries de retornos.
 
     Args:
-        returns (array): série de retornos para o qual o Sharpe Ratio será calculado.
+        returns (pd.Series): série de retornos para o qual o Sharpe Ratio será calculado.
         window (int): janela móvel para calcular o Sharpe ao longo do tempo.
         risk_free (float): valor da taxa livre de risco para cálculo do Sharpe.
-        plot (bool): se `True`, plota um gráfico de linha com o Sharpe ao longo do tempo.
 
     Returns:
         pd.Series: uma série com os valores do Sharpe para os últimos `window` dias.
@@ -174,65 +132,26 @@ def rolling_sharpe(returns, window, risk_free=0, plot=False):
     """
     rolling_sharpe = pd.Series([sharpe_ratio(returns[i - window:i], risk_free)
                                 for i in range(window, len(returns))], returns[window:].index)
-    if plot:
-        fig = px.line(rolling_sharpe, title="Sharpe móvel")
-        overall_sharpe = sharpe_ratio(returns, risk_free)
-        fig.update_layout(shapes=[
-            dict(
-                type='line',
-                xref='paper', x0=0, x1=1,
-                yref='y', y0=overall_sharpe, y1=overall_sharpe,
-                line=dict(
-                    color='grey',
-                    width=2,
-                    dash='dash'
-                )
-            )
-        ], annotations=[
-            dict(
-                text='sharpe total: %.3f' % overall_sharpe,
-                xref='paper', x=0.05,
-                yref='y', y=overall_sharpe,
-                xanchor='left'
-            )
-        ])
-        fig.update_layout(showlegend=False)
-        fig.update_xaxes(title_text='Tempo')
-        fig.update_yaxes(title_text='Sharpe móvel: ' +
-                         str(window) + ' períodos')
-        fig.show()
     return rolling_sharpe
 
-
-def ewma_volatility(returns, window, plot=False):
+def ewma_volatility(returns, window):
     """
-    Essa função possibilita a visualização da volatilidade a partir do cálculo da EWMA e da plotagem do gráfico 
-    dessa métrica ao longo de um período.
+    Essa função calcula a volatilidade por EWMA ao longo de um período.
 
     Args:
-        returns (pd.DataFrame): série de retornos para o qual o EWMA será calculado.
+        returns (pd.Series): série de retornos para o qual o EWMA será calculado.
         window (int): janela móvel para cálculo da EWMA;
-        plot (bool): se True, plota o gráfico de linha da EWMA ao longo do tempo
 
     Returns:
-        ewma_volatility (pd.DataFrame): um dataframe indexado à data com os valores de EWMA dos últimos window dias
+        pd.Series: uma série com os valores de EWMA dos últimos `window` dias
     """
 
-
     ewma_volatility = returns.ewm(span=window).std()
-    ewma_volatility = pd.Series.to_frame(ewma_volatility)
-    if plot:
-        fig = px.line(ewma_volatility, x=ewma_volatility.index,
-                      y='Close', title='EWMA')
-        fig.update_xaxes(title_text='Tempo')
-        fig.update_yaxes(title_text='EWMA')
-        fig.show()
-        return ewma_volatility
-    if plot is False:
-        return ewma_volatility
+    
+    return ewma_volatility
 
 
-def garman_klass_volatility(high_prices, low_prices, close_prices, open_prices, window, time_scale=1, plot=False):
+def garman_klass_volatility(high_prices, low_prices, close_prices, open_prices, window, time_scale=1):
     """
     Estima a volatilidade a partir dos seguintes preços: alta, baixa, abertura e fechamento
 
@@ -243,10 +162,9 @@ def garman_klass_volatility(high_prices, low_prices, close_prices, open_prices, 
         open_prices (pd.DataFrame): série de preços de abertura de uma ação
         window (int): janela das estimativa de volatilidade
         time_scale (int): fator de escala da volatilidade, por padrão é 1 (diária)
-        plot (bool): se 'True', plota um gráfico da volatilidade móvel
 
     Returns: 
-        garman_klass_vol (pd.Series): série das estimativas de volatildade
+        pd.Series: série das estimativas de volatildade
     """
 
     high_low_ratio = (1 / 2) * \
@@ -269,34 +187,6 @@ def garman_klass_volatility(high_prices, low_prices, close_prices, open_prices, 
             Period_const * np.sum(log_ratio.iloc[date - window: date])
         )
 
-    if plot:
-        fig = px.line(garman_klass_vol, title='Garman Klass')
-        fig.update_xaxes(title_text='Tempo')
-        fig.update_yaxes(title_text='Volatilidade')
-
-        mean_garman_klass = garman_klass_vol.mean()
-        fig.update_layout(shapes=[
-            dict(
-                type='line',
-                xref='paper', x0=0, x1=1,
-                yref='y', y0=mean_garman_klass, y1=mean_garman_klass,
-                line=dict(
-                    color='grey',
-                    width=2,
-                    dash='dash'
-                )
-            )
-        ], annotations=[
-            dict(
-                text='Volatilidade média: %.3f' % mean_garman_klass,
-                xref='paper', x=0.95,
-                yref='y', y=1.1 * mean_garman_klass,
-                xanchor='left'
-            )
-        ])
-
-        fig.show()
-
     return garman_klass_vol
 
 
@@ -309,10 +199,9 @@ def parkinson_volatility(high_prices, low_prices, window, time_scale=1, plot=Fal
         low (pd.DataFrame): série de preços de baixa de uma ação
         window (int): janela das estimativa de volatilidade
         time_scale (int): fator de escala da volatilidade, por padrão é 1 (diária)
-        plot (bool): se 'True', plota um gráfico da volatilidade móvel
 
     Returns: 
-        garman_klass_vol (pd.Series): série das estimativas de volatildade
+        pd.Series: série das estimativas de volatildade
 
     """
 
@@ -329,89 +218,45 @@ def parkinson_volatility(high_prices, low_prices, window, time_scale=1, plot=Fal
             Period_const * np.sum(log_ratio.iloc[date - window: date])
         )
 
-    if plot:
-        fig = px.line(parkinson_vol, title='Número de Parkinson')
-        fig.update_xaxes(title_text='Tempo')
-        fig.update_yaxes(title_text='Volatilidade')
-
-        mean_parkinson = parkinson_vol.mean()
-        fig.update_layout(shapes=[
-            dict(
-                type='line',
-                xref='paper', x0=0, x1=1,
-                yref='y', y0=mean_parkinson, y1=mean_parkinson,
-                line=dict(
-                    color='grey',
-                    width=2,
-                    dash='dash'
-                )
-            )
-        ], annotations=[
-            dict(
-                text='Volatilidade média: %.3f' % mean_parkinson,
-                xref='paper', x=0.95,
-                yref='y', y=1.1 * mean_parkinson,
-                xanchor='left'
-            )
-        ])
-        fig.show()
-
     return parkinson_vol
 
 
-def rolling_std(close_prices, return_type, window, plot=False):
+def rolling_std(returns, window):
     """
-    Essa função possibilita a visualização da volatilidade a partir do cálculo da desvio padrão móvel e da plotagem do gráfico dessa
-    métrica ao longo de um período.  
+    Essa função calcula volatilidade a partir do cálculo da desvio padrão móvel.
 
     Args:
-        close_prices (pd.DataFrame): série de preços de fechamento que será utilizado de base para o cálculo do desvio padrão móvel;
-        return_type (string): tipo de retorno (simples - 'simp' ou logarítmico - 'log') que será utilizado de base para cálculo;
+        returns (pd.Series): série de retornos para o qual o desvio padrão será calculado.
         window (int): janela móvel para cálculo do desvio padrão móvel;
-        plot (bool): se True, plota o gráfico de linha do desvio padrão móvel ao longo do tempo
 
     Returns:
-        rolling_std (pd.DataFrame): um dataframe indexado à data com os valores de desvio padrão móvel dos últimos window dias
+        pd.Series: uma série indexado à data com os valores de desvio padrão móvel dos últimos window dias
     """
 
-    returns = returns(close_prices, return_type)
-
     rolling_std = returns.rolling(window).std()
-    rolling_std = pd.Series.to_frame(rolling_std)
-
-    if plot:
-        fig = px.line(rolling_std, x=rolling_std.index,
-                      y='Close', title='Desvio Padrão Móvel')
-        fig.update_xaxes(title_text='Tempo')
-        fig.update_yaxes(title_text='Desvio padrão móvel')
-        fig.show()
 
     return rolling_std
 
 
-def returns(close_prices, return_type='log', cumulative=False):
+def returns(close_prices, return_type='simple'):
     """
     Essa função permite o cálculo rápido do retorno de uma ação ao longo do tempo.
 
     Args:
-        close_prices (pd.DataFrame): série de preços de fechamento que será utilizada de base para o cálculo do retorno;
-        return_type (string): tipo de retorno (simples - 'simp' ou logarítmico - 'log') a ser calculado;
-        cumulative (bool): se True, calculará o retorno cumulativo
+        close_prices (pd.Series): série de preços de fechamento que será utilizada de base para o cálculo do retorno;
+        return_type (string): tipo de retorno (simples - 'simple' ou logarítmico - 'log') a ser calculado;
 
     Returns:
-        returns (pd.Series): série com os valores do retorno ao longo do tempo
+        pd.Series: série com os valores do retorno ao longo do tempo
     """
-    if return_type == "log":
-        returns = np.log(close_prices/close_prices.shift(1))
-
-    elif return_type == "simp":
+    if return_type == "simple":
         returns = close_prices.pct_change()
-
+    elif return_type == "log":
+        returns = np.log(close_prices/close_prices.shift(1))
     else:
         raise ValueError("Tipo de retorno inválido")
 
     return returns
-
 
 def cumulative_returns(returns, return_type):
     """
@@ -422,32 +267,16 @@ def cumulative_returns(returns, return_type):
         return_type (string): tipo de retorno (simples - 'simp' ou logarítmico - 'log') presente na série.
 
     Returns:
-        cumulative_returns (pd.Series): série com os valores de retorno cumulativo ao longo do tempo
+        pd.Series: série com os valores de retorno cumulativo ao longo do tempo
     """
     if return_type == "log":
         cumulative_returns = returns.cumsum()
-
     elif return_type == "simp":
         cumulative_returns = (returns + 1).cumprod() - 1
-
     else:
         raise ValueError("Tipo de retorno inválido")
 
     return cumulative_returns
-
-
-def plot_allocation(dictionary):
-    """
-    Essa função permite a visualização da distribuição de pesos em um portfolio através da plotagem de um gráfico de pizza.
-
-    Args:
-        dictionary (dict): dicionário com o nome da ação e sua respectiva porcentagem na carteira, no formato ação:porcentagem.
-    """
-    labels = list(dictionary.keys())
-    values = list(dictionary.values())
-    fig = px.pie(values=values, names=labels)
-    fig.show()
-
 
 def cagr(returns, time_scale=252):
     """

--- a/turingquant/plot_metrics.py
+++ b/turingquant/plot_metrics.py
@@ -1,0 +1,264 @@
+import numpy as np
+import pandas as pd
+import plotly.express as px
+from .metrics import *
+
+
+def plot_drawdown(returns):
+    """
+    Plota o drawdown percentual para uma série de retornos.
+
+    Args:
+        returns (pd.Series): série de retornos para a qual será calculado o drawdown.
+    Returns:
+        pd.Series: uma série com os valores percentuais do Drawdown.
+    """
+
+    drawdowns = drawdown(returns)
+
+    fig = px.area(drawdowns, x=drawdowns.index,
+                    y='Drawdown', title='Underwater')
+    fig.update_xaxes(title_text='Tempo')
+    fig.update_yaxes(title_text='Drawdown (%)')
+    fig.show()
+
+    return drawdowns
+
+def plot_rolling_beta(returns, benchmark, window=60):
+    """
+    Plota o beta móvel para um ativo e um benchmark de referência, na forma de séries de retornos.
+
+    Args:
+        returns (array): série de retornos para o qual o beta será calculado.
+        benchmark (array): série de retornos para usar de referência no cálculo do beta.
+        window (int): janela móvel para calcular o beta ao longo do tempo.
+
+    Returns:
+        pd.Series: uma série com os valores do Beta para os últimos `window` dias.
+        A série não possui os `window` primeiros dias.
+
+    """
+    rolling_beta_series = rolling_beta(returns, benchmark, window=60)
+
+    fig = px.line(rolling_beta_series, title="Beta móvel")
+    overall_beta = beta(returns, benchmark)
+    fig.update_layout(shapes=[
+        dict(
+            type='line',
+            xref='paper', x0=0, x1=1,
+            yref='y', y0=overall_beta, y1=overall_beta,
+            line=dict(
+                color='grey',
+                width=2,
+                dash='dash'
+            )
+        )
+    ], annotations=[
+        dict(
+            text='beta total: %.3f' % overall_beta,
+            xref='paper', x=0.05,
+            yref='y', y=overall_beta,
+            xanchor='left'
+        )
+    ])
+    fig.update_layout(showlegend=False)
+    fig.update_xaxes(title_text='Tempo')
+    fig.update_yaxes(title_text='Beta móvel: ' + str(window) + ' períodos')
+    fig.show()
+
+    return rolling_beta_series
+
+def plot_rolling_sharpe(returns, window, risk_free=0):
+    """
+    Plota o sharpe móvel para um ativo e um benchmark de referência, na forma de séries de retornos.
+
+    Args:
+        returns (array): série de retornos para o qual o Sharpe Ratio será calculado.
+        window (int): janela móvel para calcular o Sharpe ao longo do tempo.
+        risk_free (float): valor da taxa livre de risco para cálculo do Sharpe.
+        plot (bool): se `True`, plota um gráfico de linha com o Sharpe ao longo do tempo.
+
+    Returns:
+        pd.Series: uma série com os valores do Sharpe para os últimos `window` dias.
+        A série não possui os `window` primeiros dias.
+
+    """
+    rolling_sharpe_series = rolling_sharpe(returns, window, risk_free)
+
+    fig = px.line(rolling_sharpe_series, title="Sharpe móvel")
+    overall_sharpe = sharpe_ratio(returns, risk_free)
+    fig.update_layout(shapes=[
+        dict(
+            type='line',
+            xref='paper', x0=0, x1=1,
+            yref='y', y0=overall_sharpe, y1=overall_sharpe,
+            line=dict(
+                color='grey',
+                width=2,
+                dash='dash'
+            )
+        )
+    ], annotations=[
+        dict(
+            text='sharpe total: %.3f' % overall_sharpe,
+            xref='paper', x=0.05,
+            yref='y', y=overall_sharpe,
+            xanchor='left'
+        )
+    ])
+    fig.update_layout(showlegend=False)
+    fig.update_xaxes(title_text='Tempo')
+    fig.update_yaxes(title_text='Sharpe móvel: ' +
+                        str(window) + ' períodos')
+    fig.show()
+
+    return rolling_sharpe_series
+
+def plot_ewma_volatility(returns, window):
+    """
+    Essa função possibilita a visualização da volatilidade a partir do cálculo da EWMA e da plotagem do gráfico 
+    dessa métrica ao longo de um período.
+
+    Args:
+        returns (pd.Series): série de retornos para o qual o EWMA será calculado.
+        window (int): janela móvel para cálculo da EWMA;
+
+    Returns:
+        pd.Series: uma série com os valores de EWMA dos últimos `window` dias
+    """
+
+    ewma_volatility_series = ewma_volatility(returns, window)
+    fig = px.line(ewma_volatility_series, x=ewma_volatility.index,
+                    y='Close', title='EWMA')
+    fig.update_xaxes(title_text='Tempo')
+    fig.update_yaxes(title_text='EWMA')
+    fig.show()
+
+    return ewma_volatility_series
+
+def plot_garman_klass_volatility(high_prices, low_prices, close_prices, open_prices, window, time_scale=1):
+    """
+    Plota a volatilidade a partir dos seguintes preços: alta, baixa, abertura e fechamento
+
+    Args:
+        high_prices (pd.DataFrame): série de preços de alta de uma ação
+        low_prices (pd.DataFrame): série de preços de baixa de uma ação
+        close_prices (pd.DataFrame): série de preços de fechamento de uma ação
+        open_prices (pd.DataFrame): série de preços de abertura de uma ação
+        window (int): janela das estimativa de volatilidade
+        time_scale (int): fator de escala da volatilidade, por padrão é 1 (diária)
+
+    Returns: 
+        pd.Series: série das estimativas de volatildade
+    """
+
+    garman_klass_vol = garman_klass_volatility(high_prices, low_prices, close_prices, open_prices, window, time_scale)
+
+    fig = px.line(garman_klass_vol, title='Garman Klass')
+    fig.update_xaxes(title_text='Tempo')
+    fig.update_yaxes(title_text='Volatilidade')
+
+    mean_garman_klass = garman_klass_vol.mean()
+    fig.update_layout(shapes=[
+        dict(
+            type='line',
+            xref='paper', x0=0, x1=1,
+            yref='y', y0=mean_garman_klass, y1=mean_garman_klass,
+            line=dict(
+                color='grey',
+                width=2,
+                dash='dash'
+            )
+        )
+    ], annotations=[
+        dict(
+            text='Volatilidade média: %.3f' % mean_garman_klass,
+            xref='paper', x=0.95,
+            yref='y', y=1.1 * mean_garman_klass,
+            xanchor='left'
+        )
+    ])
+
+    fig.show()
+
+    return garman_klass_vol
+
+def plot_parkinson_volatility(high_prices, low_prices, window, time_scale=1):
+    """
+    Plota a volatilidade a partir dos preços de Alta e de Baixa
+
+    Args:
+        high (pd.DataFrame): série de preços de alta de uma ação
+        low (pd.DataFrame): série de preços de baixa de uma ação
+        window (int): janela das estimativa de volatilidade
+        time_scale (int): fator de escala da volatilidade, por padrão é 1 (diária)
+
+    Returns: 
+        pd.Series: série das estimativas de volatildade
+
+    """
+
+    parkinson_vol = parkinson_volatility(high_prices, low_prices, window, time_scale)
+
+    fig = px.line(parkinson_vol, title='Número de Parkinson')
+    fig.update_xaxes(title_text='Tempo')
+    fig.update_yaxes(title_text='Volatilidade')
+
+    mean_parkinson = parkinson_vol.mean()
+    fig.update_layout(shapes=[
+        dict(
+            type='line',
+            xref='paper', x0=0, x1=1,
+            yref='y', y0=mean_parkinson, y1=mean_parkinson,
+            line=dict(
+                color='grey',
+                width=2,
+                dash='dash'
+            )
+        )
+    ], annotations=[
+        dict(
+            text='Volatilidade média: %.3f' % mean_parkinson,
+            xref='paper', x=0.95,
+            yref='y', y=1.1 * mean_parkinson,
+            xanchor='left'
+        )
+    ])
+    fig.show()
+
+    return parkinson_vol
+
+def plot_rolling_std(returns, window):
+    """
+    Essa função possibilita a visualização da volatilidade a partir do cálculo da desvio padrão móvel e da plotagem do gráfico dessa
+    métrica ao longo de um período.  
+
+    Args:
+        returns (pd.Series): série de retornos para o qual o desvio padrão será calculado.
+        window (int): janela móvel para cálculo do desvio padrão móvel;
+
+    Returns:
+        pd.Series: uma série indexado à data com os valores de desvio padrão móvel dos últimos window dias
+    """
+
+    rolling_std_series = rolling_std(returns, window)
+
+    fig = px.line(rolling_std_series, x=rolling_std_series.index,
+                    y='Close', title='Desvio Padrão Móvel')
+    fig.update_xaxes(title_text='Tempo')
+    fig.update_yaxes(title_text='Desvio padrão móvel')
+    fig.show()
+
+    return rolling_std_series
+
+def plot_allocation(dictionary):
+    """
+    Essa função permite a visualização da distribuição de pesos em um portfolio através da plotagem de um gráfico de pizza.
+
+    Args:
+        dictionary (dict): dicionário com o nome da ação e sua respectiva porcentagem na carteira, no formato ação:porcentagem.
+    """
+    labels = list(dictionary.keys())
+    values = list(dictionary.values())
+    fig = px.pie(values=values, names=labels)
+    fig.show()


### PR DESCRIPTION
Tirei as funções de plots de dentro do metrics.py e coloquei em plot_metrics.py

Aproveitei e alterei as docstrings e refatorei algumas funções do metrics.py

A ideia é que para cálculo de métricas sempre se receba como argumento pandas.Series apesar de também ser possível fazer o mesmo cálculo com numpy.array

Inclusive, isso pode ser um problema pros plots, que em alguns casos se assume que o indice da pd.Series é a data para fazer plots. Talvez seja necessário melhorar o módulo de plots no futuro também com relação a isso. Tipo deixar mais flexível para receber uma série `x`.