### PR TITLE
Add reverse cummulative returns metrics and plot

### DIFF
--- a/turingquant/metrics.py
+++ b/turingquant/metrics.py
@@ -352,4 +352,5 @@ def reverse_cummulative_returns(returns, log_returns=True):
     else:
         returns = 1 + returns 
         cum_returns = returns.iloc[::-1].cumprod().iloc[::-1]
-    return cum_returns
+    
+    return cum_returns - 1

--- a/turingquant/metrics.py
+++ b/turingquant/metrics.py
@@ -332,4 +332,24 @@ def value_at_risk(returns, confidance_level = 0.95, window = 1, method = 'varian
         var = var * np.sqrt(window)
     
     return var
+
+def reverse_cummulative_returns(returns, log_returns=True):
+    """
+    Calcula o retorno acumulativo inverso.
     
+    Calcula a quantidade de capital que alguém teria se tivesse investido 
+    uma unidade monetária em cada instante de tempo correspondente.
+    
+    Args:
+        returns (pd.Series): série de retornos para a qual será calculado o mar ratio.
+        log_returns (float): indica se o retorno utilizado é logaritmico (True, default) ou simples (False)
+    Returns:
+        cum_returns (pd.Series): retorno simples do instante `t` até o presente.
+    """
+    if log_returns is True:
+        cum_returns = returns.iloc[::-1].cumsum().iloc[::-1]
+        cum_returns = returns.apply(np.exp)
+    else:
+        returns = 1 + returns 
+        cum_returns = returns.iloc[::-1].cumprod().iloc[::-1]
+    return cum_returns

--- a/turingquant/plot_metrics.py
+++ b/turingquant/plot_metrics.py
@@ -262,3 +262,21 @@ def plot_allocation(dictionary):
     values = list(dictionary.values())
     fig = px.pie(values=values, names=labels)
     fig.show()
+
+def plot_reverse_cummulative_returns(returns, log_returns=True):
+    """
+    Plota o retorno acumulativo inverso.
+    
+    Calcula a quantidade de capital que alguém teria se tivesse investido 
+    uma unidade monetária em cada instante de tempo correspondente.
+    
+    Args:
+        returns (pd.Series): série de retornos para a qual será calculado o mar ratio.
+        log_returns (float): indica se o retorno utilizado é logaritmico (True, default) ou simples (False)
+    """
+    cum_returns = reverse_cummulative_returns(returns, log_returns)
+    fig = px.line(cum_returns, x=cum_returns.index,
+                    y=cum_returns.name, title='Reverse Cummulative Returns')
+    fig.update_xaxes(title_text='Tempo')
+    fig.update_yaxes(title_text='Retorno Simples')
+    fig.show()


### PR DESCRIPTION
Eu tive que fazer umas escolhas que não sei se estão de acordo com o estilo da lib.

1. Como lidar com retornos simples vs logarítmicos? 
    Eu coloquei um parâmetro na função, não sei se é a melhor forma, mas também não achei outra função que levasse em consideração que o retorno poderia ser desses dois tipos 
2. O reverse cummulative return sempre devolve o retorno simples. 
    Eu acho que não faz muito sentido devolver o retorno logarítmico, mesmo nos casos em que ele foi o tipo passado para a função. Como a gente tá interessando no valor do quanto a gente teria se tivesse investido 1 real, o retorno simples dá essa resposta muito mais objetivamente. 
